### PR TITLE
Allow logging of raw post body using registry.

### DIFF
--- a/app/code/community/Firegento/Logger/Helper/Data.php
+++ b/app/code/community/Firegento/Logger/Helper/Data.php
@@ -188,6 +188,7 @@ class Firegento_Logger_Helper_Data extends Mage_Core_Helper_Abstract
         if ( ! empty($_GET)) $requestData[] = '  GET|'.substr(@json_encode($_GET), 0, 1000);
         if ( ! empty($_POST)) $requestData[] = '  POST|'.substr(@json_encode($_POST), 0, 1000);
         if ( ! empty($_FILES)) $requestData[] = '  FILES|'.substr(@json_encode($_FILES), 0, 1000);
+        if (Mage::registry('raw_post_data')) $requestData[] = '  RAWPOST|'.substr(Mage::registry('raw_post_data'), 0, 1000);
         $event['REQUEST_DATA'] = $requestData ? implode("\n", $requestData) : $notAvailable;
 
 


### PR DESCRIPTION
The way PHP SAPI reads the post body allows it only to be read one time so the logger format cannot read the post body without interfering with the application. This patch allows the post body to be loggable by the user simply setting the proper registry value.
