### PR TITLE
Fix PHP Recoverable Error in cron job. Move database code to resource mo...

### DIFF
--- a/app/code/community/Firegento/Logger/Model/Observer.php
+++ b/app/code/community/Firegento/Logger/Model/Observer.php
@@ -1,54 +1,25 @@
 <?php
 class Firegento_Logger_Model_Observer extends Varien_Object
 {
+
     const MAX_FILE_DAYS = 30;
 
-    /** @var Firegento_Logger_Helper_Data */
-    private $_helper;
-
-    public function _construct()
-    {
-        parent::_construct();
-        $this->_helper = Mage::helper('firegento_logger');
-    }
-
     /**
-     * Called by cron expression in config.xml to cleanup the
-     * logs written to the DB.
-     *
-     * @param Varien_Event_Observer $observer
-     * @param int                   $days
+     * Cron job for cleaning firegento log table
      */
-    public function cleanLogs(Varien_Event_Observer $observer, $days = 0)
+    public function cleanLogsCron()
     {
-        $counter = 0;
-        if ($days == 0)
-        {
-            $days = $this->getMaximumLogMessagesInDays();
-        }
-        $delete = $this->formatDate(Mage::getModel('core/date')
-            ->gmtTimestamp() - (60 * 60 * 24 * $days));
-        /** @var $messages Firegento_Logger_Model_Resource_Db_Entry_Collection */
-        $messages = Mage::getModel('firegento_logger/db_entry')
-            ->getCollection()
-            ->addFieldToFilter('timestamp', array('lt' => $delete));
-        /** @var $message Firegento_Logger_Model_Db_Entry */
-        foreach ($messages as $message)
-        {
-            $message->delete();
-            $counter++;
-        }
-
-        Mage::log('[CRONJOB: clean_logs] Deleted ' . $counter . ' log message(s) from DB that are older than '
-        . $this->getMaximumLogMessagesInDays() . ' days.', Zend_Log::INFO);
+        Mage::getResourceSingleton('firegento_logger/db_entry')->cleanLogs(
+            Mage::helper('firegento_logger')->getMaximumLogMessagesInDays()
+        );
     }
 
     /**
      * Rotate all files in var/log which ends with .log
      *
-     * @param Varien_Event_Observer $observer
+     * @param Varien_Event_Observer|null $observer
      */
-    public function rotateLogs(Varien_Event_Observer $observer)
+    public function rotateLogs($observer = NULL)
     {
         $var = Mage::getBaseDir('log');
 

--- a/app/code/community/Firegento/Logger/Model/Resource/Db/Entry.php
+++ b/app/code/community/Firegento/Logger/Model/Resource/Db/Entry.php
@@ -1,8 +1,25 @@
 <?php
 class Firegento_Logger_Model_Resource_Db_Entry extends Mage_Core_Model_Resource_Db_Abstract
 {
+
     public function _construct()
     {
         $this->_init('firegento_logger/db_entry', 'entity_id');
+    }
+
+    /**
+     * @param int $keepDays
+     * @return int
+     */
+    public function cleanLogs($keepDays)
+    {
+        if ( ! $keepDays) {
+            return 0;
+        }
+        $delete = Varien_Date::formatDate(Mage::getModel('core/date')->gmtTimestamp() - (60 * 60 * 24 * $keepDays), FALSE);
+        return $this->_getWriteAdapter()->delete(
+            $this->getMainTable(),
+            $this->_getWriteAdapter()->quoteInto('timestamp < ?', $delete)
+        );
     }
 }

--- a/app/code/community/Firegento/Logger/etc/config.xml
+++ b/app/code/community/Firegento/Logger/etc/config.xml
@@ -12,7 +12,7 @@
                     <cron_expr>15 0 * * *</cron_expr>
                 </schedule>
                 <run>
-                    <model>firegento_logger/observer::cleanLogs</model>
+                    <model>firegento_logger/observer::cleanLogsCron</model>
                 </run>
             </clean_logs>
             <!--

--- a/shell/logger.php
+++ b/shell/logger.php
@@ -6,18 +6,19 @@ class Firegento_Logger_Shell extends Mage_Shell_Abstract
 
     public function run()
     {
-        /** @var $model Firegento_Logger_Model_Observer */
-        $model = Mage::getModel('firegento_logger/observer');
         if ($this->getArg('clean'))
         {
             $days = $this->getArg('days');
-            $model->cleanLogs(new Varien_Event_Observer(), $days);
+            if ( ! $days) {
+                $days = Mage::helper('firegento_logger')->getMaximumLogMessagesInDays();
+            }
+            $deleted = Mage::getResourceSingleton('firegento_logger/db_entry')->cleanLogs($days);
 
-            echo "Database log cleaned." . PHP_EOL;
+            echo "Database log cleaned: kept $days days, deleted $deleted records." . PHP_EOL;
         }
         elseif ($this->getArg('rotate'))
         {
-            $model->rotateLogs(new Varien_Event_Observer());
+            Mage::getSingleton('firegento_logger/observer')->rotateLogs();
             echo "Rotation of log files finished.".PHP_EOL;
         }
         else


### PR DESCRIPTION
...del and do not load logs into memory before deleting them.

I started getting this error after updating:

> Recoverable Error: Argument 1 passed to Firegento_Logger_Model_Observer::cleanLogs() must be an instance of Varien_Event_Observer, instance of Mage_Cron_Model_Schedule given  in /var/www/..../.modman/Logger/app/code/community/Firegento/Logger/Model/Observer.php on line 22

Also the method of deleting could quite easily run out of memory if the logs got flooded somehow and was generally very inefficient. Loaded all logs into collection with full-blow models and delete individually while not actually reading any of the data..
