### PR TITLE
Suggest, not require Magento Composer Installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,7 @@
   "type": "magento-module",
   "description": "FireGento Logger is an advanced alternative to log messages and errors to multiple targets.",
   "homepage": "https://github.com/firegento/firegento-logger",
-  "require": {
-    "magento-hackathon/magento-composer-installer": "*"
-  },
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "http://packages.firegento.com"
-    }
-  ]
+  "suggest": {
+    "magento-hackathon/magento-composer-installer": "Allows to manage this package as a dependency"
+  }
 }


### PR DESCRIPTION
Additionally removed repositories section as it is not needed any longer.

Refrences:
- https://github.com/magento-hackathon/magento-composer-installer/blob/master/doc/FAQ.md
- https://getcomposer.org/doc/04-schema.md#suggest
