### PR TITLE
FireGento_Logger_Model_Mail: Character-Encoding of Mail Body

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Mail.php
+++ b/src/app/code/community/FireGento/Logger/Model/Mail.php
@@ -65,10 +65,17 @@ class FireGento_Logger_Model_Mail extends Zend_Log_Writer_Mail
     public function getMail()
     {
         if ($this->_mail === null) {
-            $this->_mail = new Zend_Mail();
-
             /** @var $helper FireGento_Logger_Helper_Data */
             $helper = Mage::helper('firegento_logger');
+
+            $charset = $helper->getLoggerConfig('mailconfig/charset');
+            $charset = filter_var($charset, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES | FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH);
+            if ($charset !== false) {
+                $charset = strtolower(trim($charset));
+            }
+            $charset = strlen($charset) ? $charset : null;
+
+            $this->_mail = new Zend_Mail($charset);
 
             $storeName = Mage::app()->getStore()->getName();
             $subject = $storeName .' - Debug Information';

--- a/src/app/code/community/FireGento/Logger/etc/system.xml
+++ b/src/app/code/community/FireGento/Logger/etc/system.xml
@@ -188,6 +188,13 @@
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                         </to>
+                        <charset translate="label">
+                            <label>Charset</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment>Defaults to "iso-8859-1", suggested: "utf-8".</comment>
+                        </charset>
                     </fields>
                 </mailconfig>
                 <db translate="label">


### PR DESCRIPTION
The default content-type of outgoing logging emails is:

```
Content-Type: text/plain; charset=iso-8859-1
```

As not all sites use iso-8859-1 as charset, an option has been added
to the mail-logger to allow setting your own charset parameter value.
- Added charset setting to mailconfig
- Instantiate Zend_Mail with charset

Ref: https://github.com/firegento/firegento-logger/issues/35
