### PR TITLE
Fixed bug in require path for GELF (Graylog2)

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Graylog2.php
+++ b/src/app/code/community/FireGento/Logger/Model/Graylog2.php
@@ -18,8 +18,8 @@
  * @copyright 2013 FireGento Team (http://www.firegento.com)
  * @license   http://opensource.org/licenses/gpl-3.0 GNU General Public License, version 3 (GPLv3)
  */
-require_once 'lib/Graylog2-gelf-php/GELFMessage.php';
-require_once 'lib/Graylog2-gelf-php/GELFMessagePublisher.php';
+require_once 'Graylog2-gelf-php/GELFMessage.php';
+require_once 'Graylog2-gelf-php/GELFMessagePublisher.php';
 /**
  * Model for Graylog logging
  *


### PR DESCRIPTION
require_once 'lib/Graylog2-gelf-php/...' is not correct because the Magento root is not always in the include_path.
The directory "lib" is in the include_path, so removing "lib/" fixes this problem.
The problem occurred when you ran a Magento script which is not located in the Magento root, for example a shell script.
