### PR TITLE
Change visibility of Db class instance variables

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Db.php
+++ b/src/app/code/community/FireGento/Logger/Model/Db.php
@@ -30,19 +30,19 @@ class FireGento_Logger_Model_Db extends Zend_Log_Writer_Db
     /**
      * @var Zend_Db_Adapter Database adapter instance
      */
-    private $_db;
+    protected $_db;
 
     /**
      * @var string Name of the log table in the database
      */
-    private $_table;
+    protected $_table;
 
     /**
      * Relates database columns names to log data field keys.
      *
      * @var null|array
      */
-    private $_columnMap;
+    protected $_columnMap;
 
     /**
      * Class constructor


### PR DESCRIPTION
Change visibility of instance variables $_db, $_table and $_columnMap of class FireGento_Logger_Model_Db from private to protected to resolve the following PHP errors:

```
PHP Fatal error:  Access level to FireGento_Logger_Model_Db::$_db must be protected (as in class Zend_Log_Writer_Db) or weaker in /MAGENTO_ROOT/app/code/community/FireGento/Logger/Model/Db.php on line 29
PHP Fatal error:  Access level to FireGento_Logger_Model_Db::$_table must be protected (as in class Zend_Log_Writer_Db) or weaker in /MAGENTO_ROOT/app/code/community/FireGento/Logger/Model/Db.php on line 29
PHP Fatal error:  Access level to FireGento_Logger_Model_Db::$_columnMap must be protected (as in class Zend_Log_Writer_Db) or weaker in /MAGENTO_ROOT/app/code/community/FireGento/Logger/Model/Db.php on line 29
```
