### PR TITLE
Remove shadowing of Db class instance variables

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Db.php
+++ b/src/app/code/community/FireGento/Logger/Model/Db.php
@@ -28,23 +28,6 @@
 class FireGento_Logger_Model_Db extends Zend_Log_Writer_Db
 {
     /**
-     * @var Zend_Db_Adapter Database adapter instance
-     */
-    private $_db;
-
-    /**
-     * @var string Name of the log table in the database
-     */
-    private $_table;
-
-    /**
-     * Relates database columns names to log data field keys.
-     *
-     * @var null|array
-     */
-    private $_columnMap;
-
-    /**
      * Class constructor
      *
      * @param string $filename Filename


### PR DESCRIPTION
The instance variables $_db, $_table, and $_columnMap of the Zend_Log_Writer_Db class were redeclared in the FireGento_Logger_Model_Db class with a different visibility. This resulted in the following PHP errors:

```
PHP Fatal error:  Access level to FireGento_Logger_Model_Db::$_db must be protected (as in class Zend_Log_Writer_Db) or weaker in /MAGENTO_ROOT/app/code/community/FireGento/Logger/Model/Db.php on line 29
PHP Fatal error:  Access level to FireGento_Logger_Model_Db::$_table must be protected (as in class Zend_Log_Writer_Db) or weaker in /MAGENTO_ROOT/app/code/community/FireGento/Logger/Model/Db.php on line 29
PHP Fatal error:  Access level to FireGento_Logger_Model_Db::$_columnMap must be protected (as in class Zend_Log_Writer_Db) or weaker in /MAGENTO_ROOT/app/code/community/FireGento/Logger/Model/Db.php on line 29
```

These errors can be resolved by changing the visibility of the instance variables from private to public.

However, there is no need to redeclare the instance variables, so I have removed them.
