### PR TITLE
Logstash needs eol

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Logstash.php
+++ b/src/app/code/community/FireGento/Logger/Model/Logstash.php
@@ -77,7 +77,7 @@ class FireGento_Logger_Model_Logstash extends Zend_Log_Writer_Abstract
     }
 
     /**
-     * Builds a JSON Message that will be sent to a Logstath Server.
+     * Builds a JSON Message that will be sent to a Logstash Server.
      *
      * @param  FireGento_Logger_Model_Event $event           A Magento Log Event.
      * @param  bool                         $enableBacktrace Indicates if a backtrace should be added to the log event.

--- a/src/app/code/community/FireGento/Logger/Model/Logstash.php
+++ b/src/app/code/community/FireGento/Logger/Model/Logstash.php
@@ -98,7 +98,9 @@ class FireGento_Logger_Model_Logstash extends Zend_Log_Writer_Abstract
         $fields['source_host'] = $event->getHostname();
         $fields['message'] = $event->getMessage();
 
-        return json_encode($fields);
+        // udp/tcp inputs require a trailing EOL character.
+        $encodedMessage = trim(json_encode($fields)) . "\n";
+        return $encodedMessage;
     }
 
     /**


### PR DESCRIPTION
I had trouble using the Logstash feature until I realized that the [TCP input documentation](http://www.logstash.net/docs/latest/inputs/tcp) says

> each event is assumed to be one line of text.

LogStash would only recognize the message after I added a newline to the end of the JSON-encoded string.