### PR TITLE
Publish Log Messages to Redis

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Redis.php
+++ b/src/app/code/community/FireGento/Logger/Model/Redis.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This file is part of a FireGento e.V. module.
+ *
+ * This FireGento e.V. module is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This script is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * PHP version 5
+ *
+ * @category  FireGento
+ * @package   FireGento_Logger
+ * @author    FireGento Team <team@firegento.com>
+ * @copyright 2013 FireGento Team (http://www.firegento.com)
+ * @license   http://opensource.org/licenses/gpl-3.0 GNU General Public License, version 3 (GPLv3)
+ */
+/**
+ * Model for Redis
+ *
+ * @category FireGento
+ * @package  FireGento_Logger
+ * @author   FireGento Team <team@firegento.com>
+ */
+class FireGento_Logger_Model_Redis extends Zend_Log_Writer_Abstract
+{
+    /**
+     * @var bool Indicates if backtrace should be added to the Log Message.
+     */
+    protected $_enableBacktrace = false;
+    protected $_redisServer = false;
+    protected $_redisPort = false;
+    protected $_redisKey = false;
+    protected $_options = null;
+    /**
+     * @var int The timeout to apply when sending data to Redis servers, in seconds.
+     */
+    protected $_timeout = 5;
+
+    /**
+     * Class constructor
+     *
+     * @param string $filename Filename
+     */
+    public function __construct($filename)
+    {
+        /* @var $helper FireGento_Logger_Helper_Data */
+        $helper = Mage::helper('firegento_logger');
+        $this->_redisServer = $helper->getLoggerConfig('redis/host');
+        $this->_redisPort = $helper->getLoggerConfig('redis/port');
+        $this->_redisProtocol = $helper->getLoggerConfig('redis/protocol');
+        $this->_redisKey = $helper->getLoggerConfig('redis/key');
+    }
+
+    /**
+     * Satisfy newer Zend Framework
+     *
+     * @param  array|Zend_Config $config Configuration
+     * @return void|Zend_Log_FactoryInterface
+     */
+    public static function factory($config)
+    {
+
+    }
+
+    /**
+     * Setter for class variable _enableBacktrace
+     *
+     * @param bool $flag Flag for Backtrace
+     */
+    public function setEnableBacktrace($flag)
+    {
+        $this->_enableBacktrace = $flag;
+    }
+
+    /**
+     * Builds a JSON Message that will be sent to a Redis server.
+     *
+     * @param  FireGento_Logger_Model_Event $event           A Magento Log Event.
+     * @param  bool                         $enableBacktrace Indicates if a backtrace should be added to the log event.
+     * @return string A JSON structure representing the message.
+     */
+    protected function buildJSONMessage($event, $enableBacktrace = false)
+    {
+        Mage::helper('firegento_logger')->addEventMetadata($event, '-', $enableBacktrace);
+
+        $fields = array();
+        $fields['@timestamp'] = date('c', strtotime($event->getTimestamp()));
+        $fields['@version'] = "1";
+        $fields['level'] = $event->getPriority();
+        $fields['file'] = $event->getFile();
+        $fields['LineNumber'] = $event->getLine();
+        $fields['StoreCode'] = $event->getStoreCode();
+        $fields['TimeElapsed'] = $event->getTimeElapsed();
+        $fields['source_host'] = $event->getHostname();
+        $fields['message'] = $event->getMessage();
+
+        return json_encode($fields);
+    }
+
+    /**
+     * Sends a JSON Message to Redis.
+     *
+     * @param  string $message The JSON-Encoded Message to be sent.
+     * @throws Zend_Log_Exception
+     * @return bool True if message was sent correctly, False otherwise.
+     */
+    protected function publishMessage($message)
+    {
+        /* @var $helper FireGento_Logger_Helper_Data */
+        $helper = Mage::helper('firegento_logger');
+
+        $fp = fsockopen(
+            $this->_redisServer,
+            $this->_redisPort,
+            $errorNumber,
+            $errorMessage,
+            $this->_timeout
+        );
+        $redisCommand = sprintf("PUBLISH %s '%s'\n", $this->_redisKey, addcslashes($message, "'"));
+        try {
+            $result = fwrite($fp, $redisCommand);
+            fclose($fp);
+
+            if ($result == false) {
+                throw new Zend_Log_Exception(
+                    sprintf($helper->__('Error occurred posting log message to redis via tcp. Posted Message: %s'),
+                    $message)
+                );
+            }
+        } catch (Exception $e) {
+            throw new Zend_Log_Exception($e->getMessage(), $e->getCode());
+        }
+
+        return true;
+    }
+
+    /**
+     * Places event line into array of lines to be used as message body.
+     *
+     * @param  array $event Event data
+     * @return bool True if message was sent correctly, False otherwise.
+     */
+    protected function _write($event)
+    {
+        $event = Mage::helper('firegento_logger')->getEventObjectFromArray($event);
+        $message = $this->buildJSONMessage($event, $this->_enableBacktrace);
+        return $this->publishMessage($message);
+    }
+}

--- a/src/app/code/community/FireGento/Logger/etc/config.xml
+++ b/src/app/code/community/FireGento/Logger/etc/config.xml
@@ -150,6 +150,10 @@
                         <label>Logstash Logger</label>
                         <class>FireGento_Logger_Model_Logstash</class>
                     </logstash>
+                    <redis>
+                        <label>Redis Logger</label>
+                        <class>FireGento_Logger_Model_Redis</class>
+                    </redis>
                 </writer_models>
             </core>
         </log>
@@ -235,6 +239,15 @@ FILE: %file%:%line%
                 <port>6666</port>
                 <protocol>udp</protocol>
             </logstash>
+            <redis>
+                <priority>default</priority>
+                <host>127.0.0.1</host>
+                <port>6379</port>
+                <db>0</db>
+                <key>magento-log</key>
+                <password/>
+                <type>magento-log</type>
+            </redis>
         </logger>
     </default>
 </config>

--- a/src/app/code/community/FireGento/Logger/etc/system.xml
+++ b/src/app/code/community/FireGento/Logger/etc/system.xml
@@ -590,6 +590,58 @@
                         </protocol>
                     </fields>
                 </logstash>
+                <redis translate="label">
+                    <label>Redis Logger Configuration</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>150</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <fields>
+                        <priority translate="label">
+                            <label>Priority Level Filter</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>firegento_logger/system_config_source_prioritydefault</source_model>
+                            <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment>Choose the lowest priority level to be logged.</comment>
+                        </priority>
+                        <host>
+                            <label>Host</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                        </host>
+                        <port>
+                            <label>Port</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-digits required-entry</validate>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                        </port>
+                        <password translate="label">
+                            <label>Password</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                        </password>
+                        <db>
+                            <label>Redis Db Number</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-zero-or-greater</validate>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment><![CDATA[The <a href="http://www.rediscookbook.org/multiple_databases.html">Redis database number</a>.]]></comment>
+                        </db>
+                        <key>
+                            <label>Key</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-emailSender</validate>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment>The name of a Redis list or channel.</comment>
+                        </key>
+                    </fields>
+                </redis>
             </groups>
         </logger>
     </sections>


### PR DESCRIPTION
If you have lots of systems to keep track of you probably need fast middlemen to handle the logging. This PR adds a functional Redis target for logging. My intent is that it be used with a robust upstream logging solution like LogStash, but without requiring LogStash to take the log messages directly.

It doesn't add any dependencies. I elected to write to the socket directly because Redis is pretty simple.

Password authentication to Redis is not implemented.