### PR TITLE
[~BUGFIX] If there is no var/log folder now there is no exception

### DIFF
--- a/src/app/code/community/FireGento/Logger/Block/Adminhtml/LiveView.php
+++ b/src/app/code/community/FireGento/Logger/Block/Adminhtml/LiveView.php
@@ -35,8 +35,14 @@ class FireGento_Logger_Block_Adminhtml_LiveView extends Mage_Adminhtml_Block_Tem
     public function getLogFiles()
     {
         $logFiles = array();
+        $logFolderPath = Mage::getBaseDir('var') . DS . 'log';
 
-        $directory = new DirectoryIterator(Mage::getBaseDir('var') . DS . 'log');
+        if (!file_exists($logFolderPath)) {
+            mkdir($logFolderPath, 0755, true);
+        }
+
+        $directory = new DirectoryIterator($logFolderPath);
+
         foreach ($directory as $fileInfo) {
             if (!$fileInfo->isFile() || !preg_match('/\.(?:log)$/', $fileInfo->getFilename())) {
                 continue;


### PR DESCRIPTION
With this change, there is no exception, if there is no var/log folder, if you want to use System -> Firegento Logger -> Logger Live View for example. 