### PR TITLE
Improved browser logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ firegento community.
 
 See the [**Usage**](#usage) Chapter below to see how to use it.
 
-Pleas be aware of the following restrictions:
+Please be aware of the following restrictions:
 
 * The ProxiBlue NewRelic extension use the same logic to log to NewRelic and will block
   FireGento Logger extension.

--- a/src/app/code/community/FireGento/Logger/Helper/Data.php
+++ b/src/app/code/community/FireGento/Logger/Helper/Data.php
@@ -317,13 +317,15 @@ class FireGento_Logger_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $countSubkeys = count($subkeys);
         $lastSubkey = ($countSubkeys - 1);
-        $subdata =& $data;
+        $subdata = &$data;
         for ($i = 0; $i < $lastSubkey; $i++) {
             if (isset($subdata[$subkeys[$i]])) {
-                $subdata =& $subdata[$subkeys[$i]];
+                $subdata =  &$subdata[$subkeys[$i]];
             }
         }
-        $subdata[$subkeys[$lastSubkey]] = '*****';
+        if (array_key_exists($subkeys[$lastSubkey], $subdata)) {
+            $subdata[$subkeys[$lastSubkey]] = '*****';
+        }
         return $data;
     }
 

--- a/src/app/code/community/FireGento/Logger/Model/Queue.php
+++ b/src/app/code/community/FireGento/Logger/Model/Queue.php
@@ -118,9 +118,10 @@ class FireGento_Logger_Model_Queue extends Zend_Log_Writer_Abstract
      */
     public function shutdown()
     {
+        $cacheSize =  count($this->_loggerCache);
         foreach ($this->_writers as $writer) {
             //only implode if queue is enabled and cache has entries
-            if ($this->_useQueue && count($this->_loggerCache) > 0) {
+            if ($this->_useQueue && $cacheSize > 0) {
                 $writer->write($this->implodeEvents($this->_loggerCache));
             }
             $writer->shutdown();
@@ -157,6 +158,8 @@ class FireGento_Logger_Model_Queue extends Zend_Log_Writer_Abstract
      * Override this method since Mage::log doesn't let us set a formatter any other way.
      *
      * @param Zend_Log_Formatter_Interface $formatter Formatter
+     *
+     * @return void
      */
     public function setFormatter(Zend_Log_Formatter_Interface $formatter)
     {

--- a/src/app/code/community/FireGento/Logger/controllers/ErrorController.php
+++ b/src/app/code/community/FireGento/Logger/controllers/ErrorController.php
@@ -32,6 +32,12 @@ class FireGento_Logger_ErrorController extends Mage_Core_Controller_Front_Action
      */
     public function sendAction()
     {
+        foreach (explode(';', Mage::getStoreConfig('logger/general/frontend_bots')) as $agent) {
+            if (isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'], trim($agent)) !== false) {
+                return;
+            }
+        }
+
         $params = $this->getRequest()->getPost();
         $message = '';
         foreach ($params as $paramKey => $paramValue) {

--- a/src/app/code/community/FireGento/Logger/controllers/ErrorController.php
+++ b/src/app/code/community/FireGento/Logger/controllers/ErrorController.php
@@ -32,9 +32,11 @@ class FireGento_Logger_ErrorController extends Mage_Core_Controller_Front_Action
      */
     public function sendAction()
     {
-        $request = $this->getRequest();
-        $errorMessage = 'MESSAGE|' . $request->getParam('message') . "\n";
-        $errorMessage = 'URL|' . $request->getParam('url');
-        Mage::log($errorMessage, ZEND_LOG::ERR);
+        $params = $this->getRequest()->getPost();
+        $message = '';
+        foreach ($params as $paramKey => $paramValue) {
+            $message .= $paramKey.': '.$paramValue."\n";
+        }
+        Mage::log($message, Zend_Log::ERR, 'js_error.log');
     }
 }

--- a/src/app/code/community/FireGento/Logger/etc/config.xml
+++ b/src/app/code/community/FireGento/Logger/etc/config.xml
@@ -188,6 +188,7 @@ password
 confirmation]]></filter_request_data>
                 <max_backtrace_lines>0</max_backtrace_lines>
                 <viewer_enabled>0</viewer_enabled>
+                <frontend_bots><![CDATA[Teoma;alexa;froogle;Gigabot;inktomi;looksmart;URL_Spider_SQL;Firefly;NationalDirectory;Ask Jeeves;TECNOSEEK;InfoSeek;WebFindBot;girafabot;crawler;www.galaxy.com;Googlebot;Scooter;Slurp;msnbot;appie;FAST;WebBug;Spade;ZyBorg;rabaz;Baiduspider;Feedfetcher-Google;TechnoratiSnoop;Rankivabot;Mediapartners-Google;Sogou web spider;WebAlta Crawler]]></frontend_bots>
             </general>
             <default>
                 <priority>default</priority>

--- a/src/app/code/community/FireGento/Logger/etc/system.xml
+++ b/src/app/code/community/FireGento/Logger/etc/system.xml
@@ -122,6 +122,13 @@
                                 send these errors also to the configured logging backend. <br />
                             ]]></comment>
                         </frontend_logger>
+                        <frontend_bots>
+                            <label>Frontend Logger Exclude Bots</label>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment>Field above is used to match any of semicolon separated values inside user agent string and to decide whether bot or real user is currently browsing.</comment>
+                        </frontend_bots>
                         <viewer_enabled translate="label">
                             <label>Enable Log Viewer</label>
                             <frontend_type>select</frontend_type>

--- a/src/app/design/frontend/base/default/template/firegento_logger/js.phtml
+++ b/src/app/design/frontend/base/default/template/firegento_logger/js.phtml
@@ -1,11 +1,26 @@
 <script type="text/javascript">
-    window.onerror = function (message, url, lineNumber) {
-        var xhttp = new XMLHttpRequest();
+    window.onerror = function (msg, file, line, col, err)
+    {
+        var parameters = {
+            message: msg,
+            url: window.location,
+            file: file,
+            line: line,
+            col: col
+        };
+
+        if (err) {
+            parameters.stack = err.stack;
+        }
 
         // build parameters
-        var params = 'message=' + encodeURIComponent(message);
-        params += '&url=' + encodeURIComponent(document.location);
+        var params = [];
+        for (var param in parameters) {
+            params.push(param+'='+encodeURIComponent(parameters[param]));
+        }
+        params = params.join('&');
 
+        var xhttp = new XMLHttpRequest();
         xhttp.open("POST", '<?php echo $this->getUrl('logger/error/send'); ?>', true);
         xhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
         xhttp.send(params);

--- a/src/app/design/frontend/base/default/template/firegento_logger/js.phtml
+++ b/src/app/design/frontend/base/default/template/firegento_logger/js.phtml
@@ -12,6 +12,5 @@
 
         // continue with default error handler
         return false;
-    }
-    ;
+    };
 </script>


### PR DESCRIPTION
- [x] Log more parameters
- [x] Exclude Bots
- [ ] Get a better debug stack trace + code snippet.

```
var parameters = {
    message: msg,
    url: window.location,
    file: file,
    line: line,
    col: col
};
```

I'm still trying to figure out how to debug inline scripts... Usually the line number is useless and the msg doesn't really help either. Ideally I'd like to include a code snippet which is responsible for the error.. Don't know if that is possible somehow.

For example, I'm getting the following errors, which are absolutely useless..

```
message: Script error.
url: http://www.finitro.pt/checkout/onepage/index/
file: 
line: 0
col: 0
```
