### PR TITLE
Saving DB timestamps in UTC and improving grid filtering

### DIFF
--- a/src/app/code/community/FireGento/Logger/Block/Adminhtml/Logger/Grid.php
+++ b/src/app/code/community/FireGento/Logger/Block/Adminhtml/Logger/Grid.php
@@ -87,6 +87,7 @@ class FireGento_Logger_Block_Adminhtml_Logger_Grid
 
         $this->addColumn('timestamp', array(
             'header' => Mage::helper('firegento_logger')->__('Timestamp'),
+            'type' => 'datetime',
             'align' => 'left',
             'index' => 'timestamp',
         ));

--- a/src/app/code/community/FireGento/Logger/Model/Db.php
+++ b/src/app/code/community/FireGento/Logger/Model/Db.php
@@ -105,6 +105,7 @@ class FireGento_Logger_Model_Db extends Zend_Log_Writer_Db
             $dataToInsert['advanced_info'] = $this->getAdvancedInfo($event);
         }
 
+        $dataToInsert['timestamp'] = Mage::getSingleton('core/date')->gmtDate();
         $this->_db->insert($this->_table, $dataToInsert);
 
         /** @var Varien_Db_Adapter_Pdo_Mysql $db */


### PR DESCRIPTION
This PR will add "From" and "To" filters to the Timestamp column:

![image](https://i.imgur.com/0EqGx8s.png)

It also forces saving DB timestamps in UTC timezone, not whatever timezone MySQL uses as `CURRENT_TIMESTAMP`.  The `datetime` column type will then convert it to the admin's configured timezone.