### PR TITLE
Trim keys to filter

### DIFF
--- a/src/app/code/community/FireGento/Logger/Helper/Data.php
+++ b/src/app/code/community/FireGento/Logger/Helper/Data.php
@@ -297,6 +297,7 @@ class FireGento_Logger_Helper_Data extends Mage_Core_Helper_Abstract
             $keysToFilter = explode("\n",
                 Mage::helper('firegento_logger')->getLoggerConfig('general/filter_request_data'));
             foreach ($keysToFilter as $key) {
+                $key = trim($key);
                 if ($key !== '') {
                     $subkeys = explode('.', $key);
                     $data = $this->filterDataFromMultidimensionalKey($data, $subkeys);


### PR DESCRIPTION
Exploding on "\n" doesn't always get rid of all control characters. Trim the results so that keys can match. 

Was the cause of #83