### PR TITLE
skip frontend-logger if isDevAllowed

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Observer.php
+++ b/src/app/code/community/FireGento/Logger/Model/Observer.php
@@ -143,7 +143,7 @@ class FireGento_Logger_Model_Observer extends Varien_Object
      */
     public function addLoggerJs(Varien_Event_Observer $observer)
     {
-        if ($this->init && !Mage::helper('core')->isDevAllowed()) {
+        if ($this->init && Mage::helper('core')->isDevAllowed()) {
             $this->init = false;
         }
 

--- a/src/app/code/community/FireGento/Logger/etc/config.xml
+++ b/src/app/code/community/FireGento/Logger/etc/config.xml
@@ -271,6 +271,7 @@ confirmation]]></filter_request_data>
             <core_block_abstract_to_html_after>
                 <observers>
                     <add_logger_js>
+                        <type>singleton</type>
                         <class>FireGento_Logger_Model_Observer</class>
                         <method>addLoggerJs</method>
                     </add_logger_js>

--- a/src/app/code/community/FireGento/Logger/etc/system.xml
+++ b/src/app/code/community/FireGento/Logger/etc/system.xml
@@ -119,7 +119,8 @@
                             <show_in_default>1</show_in_default>
                             <comment><![CDATA[
                                 When set to "Yes", JS errors in the frontend will be send to an action to
-                                send these errors also to the configured logging backend. <br />
+                                send these errors also to the configured logging backend. <br> />
+                                Note: only if client is not defined in dev/restrict/allow_ips <br />
                             ]]></comment>
                         </frontend_logger>
                         <viewer_enabled translate="label">


### PR DESCRIPTION
IMHO there is no need for the FE-logger if Developer is viewing the page.
Background: If AOE TemplateHints is installed and query param ath=1, TemplateHints registers its JS before the logger JS. This leads to further JS errors. First approach was to check whether AOE TemplateHints is enabled or not, but this is much more consuming. So this approach is, to check whether isDevAllowed or not, because AOE TemplateHints are not rendered anyway if isDevAllowed equals to false.

PS:
Bonus of this PR is, if head-block is once matched (=FE-logger JS block rendered), the observer will not consume processing time further.