### PR TITLE
Corrected a bug which prevents Exceptions being written to Graylog

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Graylog2.php
+++ b/src/app/code/community/FireGento/Logger/Model/Graylog2.php
@@ -112,7 +112,7 @@ class FireGento_Logger_Model_Graylog2 extends Zend_Log_Writer_Abstract
 
             Mage::helper('firegento_logger')->addEventMetadata($event);
 
-	        $message = trim($event->getMessage());
+            $message = trim($event->getMessage());
 
             $eofMessageFirstLine = strpos($message, "\n");
             $shortMessage = (false === $eofMessageFirstLine) ? $message :

--- a/src/app/code/community/FireGento/Logger/Model/Graylog2.php
+++ b/src/app/code/community/FireGento/Logger/Model/Graylog2.php
@@ -112,7 +112,7 @@ class FireGento_Logger_Model_Graylog2 extends Zend_Log_Writer_Abstract
 
             Mage::helper('firegento_logger')->addEventMetadata($event);
 
-            $message = $event->getMessage();
+	        $message = trim($event->getMessage());
 
             $eofMessageFirstLine = strpos($message, "\n");
             $shortMessage = (false === $eofMessageFirstLine) ? $message :


### PR DESCRIPTION
Der Fix ist notwendig, damit Exceptions an Graylog geloggt werden.

Begründung:
Magento stellt allen Exceptions ein EOL voran.
Mage.php::logException

`self::log("\n" . $e->__toString(), Zend_Log::ERR, $file);`

Ohne die Trim Funktion bleibt die Shortmessage leer
FireGento_Logger_Model_Graylog2::_write
            
`$message = trim($event->getMessage());
$eofMessageFirstLine = strpos($message, "\n");
$shortMessage = (false === $eofMessageFirstLine) ? $message : substr($message, 0, $eofMessageFirstLine);`

Mit einer leeren Shortmessage wird so eine Nachricht im GELF verworfen bzw eine Exception geworfen:
FireGento_Logger_Model_Graylog2::publish

`// Check if required message parameters are set
if(!$message->getShortMessage() || !$message->getHost()) {
            throw new UnexpectedValueException(
                'Missing required data parameter: "version", "short_message" and "host" are required.'
            );
        }`


