### PR TITLE
Fixed FireGento_Logger_Model_JsonStream logger

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/JsonStream.php
+++ b/src/app/code/community/FireGento/Logger/Model/JsonStream.php
@@ -76,7 +76,7 @@ class FireGento_Logger_Model_JsonStream extends Zend_Log_Writer_Stream
         $eventData = array_filter($eventData, function ($var) { return $var !== null; });
         $line = @json_encode($eventData);
 
-        if (false === @fwrite($this->_stream, $line)) {
+        if (false === @fwrite($this->_stream, $line . PHP_EOL)) {
             //require_once 'Zend/Log/Exception.php';
             throw new Zend_Log_Exception("Unable to write to stream");
         }

--- a/src/app/code/community/FireGento/Logger/Model/JsonStream.php
+++ b/src/app/code/community/FireGento/Logger/Model/JsonStream.php
@@ -73,7 +73,7 @@ class FireGento_Logger_Model_JsonStream extends Zend_Log_Writer_Stream
         $event = Mage::helper('firegento_logger')->getEventObjectFromArray($event);
         Mage::helper('firegento_logger')->addEventMetadata($event, NULL, $this->_enableBacktrace);
         $eventData = $event->getEventDataArray();
-        $eventData = array_filter($eventData, 'is_null');
+        $eventData = array_filter($eventData, function ($var) { return $var !== null; });
         $line = @json_encode($eventData);
 
         if (false === @fwrite($this->_stream, $line)) {

--- a/src/app/code/community/FireGento/Logger/Model/JsonStream.php
+++ b/src/app/code/community/FireGento/Logger/Model/JsonStream.php
@@ -25,7 +25,7 @@
  * @package  FireGento_Logger
  * @author   FireGento Team <team@firegento.com>
  */
-class FireGento_Logger_Model_Stream extends Zend_Log_Writer_Stream
+class FireGento_Logger_Model_JsonStream extends Zend_Log_Writer_Stream
 {
     /**
      * @var bool


### PR DESCRIPTION
The name of the class `FireGento_Logger_Model_Json` should be `FireGento_Logger_Model_JsonStream`.