### PR TITLE
some logs / all logs(?) don't seem to have a timestamp set, which cau…

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Papertrailsyslog.php
+++ b/src/app/code/community/FireGento/Logger/Model/Papertrailsyslog.php
@@ -107,7 +107,7 @@ class FireGento_Logger_Model_Papertrailsyslog extends FireGento_Logger_Model_Rsy
             $message,
             16,
             $priority,
-            strtotime($event->getTimestamp()),
+            strtotime(($event->getTimestamp())?$event->getTimestamp():now()),
             [
                 'HostName' => sprintf(
                     '%s %s/%s',


### PR DESCRIPTION
TBH, not 100% sure why this is happening, but at times some log entries being formulated has no timeStamp attached to the event object.

I tried to trace, but after a while could not find reason.

I added a fix that sets the timestamp to current (now) if empty.

