### PR TITLE
no timestamp

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Papertrailsyslog.php
+++ b/src/app/code/community/FireGento/Logger/Model/Papertrailsyslog.php
@@ -107,7 +107,7 @@ class FireGento_Logger_Model_Papertrailsyslog extends FireGento_Logger_Model_Rsy
             $message,
             16,
             $priority,
-            strtotime(($event->getTimestamp())?$event->getTimestamp():now()),
+            strtotime($event->getTimestamp()),
             [
                 'HostName' => sprintf(
                     '%s %s/%s',

--- a/src/app/code/community/FireGento/Logger/Model/Papertrailsyslog.php
+++ b/src/app/code/community/FireGento/Logger/Model/Papertrailsyslog.php
@@ -107,7 +107,7 @@ class FireGento_Logger_Model_Papertrailsyslog extends FireGento_Logger_Model_Rsy
             $message,
             16,
             $priority,
-            strtotime($event->getTimestamp()),
+            strtotime(($event->getTimestamp())?$event->getTimestamp():now()),
             [
                 'HostName' => sprintf(
                     '%s %s/%s',

--- a/src/app/code/community/FireGento/Logger/Model/Rsyslog.php
+++ b/src/app/code/community/FireGento/Logger/Model/Rsyslog.php
@@ -177,7 +177,9 @@ class FireGento_Logger_Model_Rsyslog extends Zend_Log_Writer_Abstract
     protected function _write($event)
     {
         $event = Mage::helper('firegento_logger')->getEventObjectFromArray($event);
-
+        if(!$event->getTimestamp()) {
+            $event->setTimestamp(now());
+        }
         $message = $this->buildSysLogMessage($event);
         return $this->publishMessage($message);
     }


### PR DESCRIPTION
All rsyslog logging seemed to be missing a needed timestamp.
Not sure why there is no timestamp on the event, as it is blocked by rsyslog lib if not set:

This change simply sets a timestamp, if none set.
