### PR TITLE
Set prefixes option for Sentry to improve grouping events into issues

### DIFF
--- a/src/app/code/community/FireGento/Logger/Model/Sentry.php
+++ b/src/app/code/community/FireGento/Logger/Model/Sentry.php
@@ -84,6 +84,7 @@ class FireGento_Logger_Model_Sentry extends FireGento_Logger_Model_Abstract
             $options            = [
                 'trace'       => $this->_enableBacktrace,
                 'curl_method' => $helper->getLoggerConfig('sentry/curl_method'),
+                'prefixes'    => [BP],
             ];
             if ($environment = trim($helper->getLoggerConfig('sentry/environment'))) {
                 $options['environment'] = $environment;


### PR DESCRIPTION
### Current problem

The absolute base path of an application may change over time. For example, in our case, when we deploy a new version of the application, the code is put into a new release directory (named after the release date and time). There may also be other reasons why the application base path changes.

As a result, the base path in file names in the exception traces of Sentry events differ, even when it's exactly the same exception. The consequence of this is that those events are not grouped into the same issues, because [Sentry groups events based on paths in exception traces](https://docs.sentry.io/data-management/event-grouping/#grouping-by-stacktrace).

### Prefixes to the rescue

The solution is to provide the current base path as a prefix to Sentry. Sentry will then remove this prefix in all exception traces, resulting in a correct grouping of events. The default behavior of the Sentry PHP client is to use the include paths as prefixes. This almost works right for Magento, however the location of `Mage.php` is not in the include path, so the full path to `Mage.php` is always shown in the exception traces, resulting in incorrect event grouping.

### Solution

Pass the Magento base path as prefix to the Sentry client to make all paths relative to the base directory.