### PR TITLE
[FIX] Correctly determine stored target maps

### DIFF
--- a/src/app/code/community/FireGento/Logger/Helper/Data.php
+++ b/src/app/code/community/FireGento/Logger/Helper/Data.php
@@ -106,7 +106,7 @@ class FireGento_Logger_Helper_Data extends Mage_Core_Helper_Abstract
                         }
                     }
                 }
-                $this->_targetMap = $targetMap;
+                $this->_targetMap = $targets;
             } else {
                 $this->_targetMap = false;
             }


### PR DESCRIPTION
Target maps are broken since the release of v1.10.

The issue is introduced in commit 8d6af82, where some refactoring has been applied to the method `FireGento_Logger_Helper_Data::getMappedTargets`. In this method a `$targets` array variable is populated when looping over the `$targetMap` variable (which contains the unserialized results of `$this->getLoggerConfig('general/target_map')`). However, instead of assigning the contents of the resulting `$targets` array to `$this->_targetMap`, the original `$targetMap` variable is assigned to it.

The result is that no target will ever match, and logging is effectively disabled (when using target maps).

This PR makes sure target maps are supported again.