### PR TITLE
Resolve PHP 7.4 incompatibility in the Raven client

### DIFF
--- a/src/lib/sentry/lib/Raven/Client.php
+++ b/src/lib/sentry/lib/Raven/Client.php
@@ -321,7 +321,7 @@ class Raven_Client
         // we need app_path to have a trailing slash otherwise
         // base path detection becomes complex if the same
         // prefix is matched
-        if ($path{0} === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
+        if ($path[0] === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
             $path .= DIRECTORY_SEPARATOR;
         }
         return $path;


### PR DESCRIPTION
This PR resolves a PHP 7.4 incompatibility in the `Raven_Client` class.

The following was reported by the [PHP Compatibility Coding Standard for PHP_CodeSniffer](https://github.com/PHPCompatibility/PHPCompatibility) regarding this incompatibility:

    FILE: /path/to/lib/sentry/lib/Raven/Client.php
    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    FOUND 1 WARNING AFFECTING 1 LINE
    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     324 | WARNING | [x] Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4. Found: $path{0}
    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

NB Technically, it would be better to upgrade the client to the latest version, but this requires more effort than just fixing this single incompatibility.